### PR TITLE
NEST update, impl. FindAsync w/ GET , decoupled Id

### DIFF
--- a/src/Bmbsqd.ElasticIdentity.Tests/Bmbsqd.ElasticIdentity.Tests.csproj
+++ b/src/Bmbsqd.ElasticIdentity.Tests/Bmbsqd.ElasticIdentity.Tests.csproj
@@ -30,14 +30,16 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elasticsearch.Net">
-      <HintPath>..\..\packages\Elasticsearch.Net.1.0.0-beta1\lib\Elasticsearch.Net.dll</HintPath>
+    <Reference Include="Elasticsearch.Net, Version=1.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Elasticsearch.Net.1.0.0-rc1\lib\Elasticsearch.Net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNet.Identity.Core">
       <HintPath>..\..\packages\Microsoft.AspNet.Identity.Core.2.0.1\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Nest">
-      <HintPath>..\..\packages\NEST.1.0.0-beta1\lib\Nest.dll</HintPath>
+    <Reference Include="Nest, Version=1.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\NEST.1.0.0-rc1\lib\Nest.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -64,6 +66,9 @@
       <Project>{B5C9EE8E-05AD-441B-BFEB-A7A9B32445C9}</Project>
       <Name>Bmbsqd.ElasticIdentity</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Bmbsqd.ElasticIdentity.Tests/CustomNames.cs
+++ b/src/Bmbsqd.ElasticIdentity.Tests/CustomNames.cs
@@ -71,13 +71,13 @@ namespace Bmbsqd.ElasticIdentity.Tests
 				AssertIdentityResult( await userManager.CreateAsync( user, "some password" ) );
 
 
-				var response = Client.Get<ElasticUser>( user.UserName, indexName, entityName );
+				var response = Client.Get<ElasticUser>( user.Id, indexName, entityName );
 				Assert.That( response.Source, Is.Not.Null );
 				Assert.That( response.Source.UserName, Is.EqualTo( user.UserName ) );
 
 			}
 			finally {
-				//Client.DeleteIndex( i => i.Index( indexName ) );
+				Client.DeleteIndex( i => i.Index( indexName ) );
 			}
 
 		}

--- a/src/Bmbsqd.ElasticIdentity.Tests/Methods.cs
+++ b/src/Bmbsqd.ElasticIdentity.Tests/Methods.cs
@@ -37,27 +37,20 @@ namespace Bmbsqd.ElasticIdentity.Tests
 
 		private ElasticUserStore<ElasticUser> CreateStore()
 		{
-			return new ElasticUserStore<ElasticUser>( _connectionString, forceRecreate: true );
-		}
+			return new ElasticUserStore<ElasticUser>( _connectionString, indexName: _defaultIndex, forceRecreate: true ) ;
+		}		
 
-		private async Task CreateUser( IUserStore<ElasticUser> store, ElasticUser user )
-		{
-			var manager = new UserManager<ElasticUser>( store );
-			AssertIdentityResult(
-				await manager.CreateAsync( user, "some-password" ) );
-		}
-
-		[TearDown]
-		public void Done()
-		{
-			Client.DeleteIndex( i => i.Index( "users" ) );
-		}
+        [TearDown]
+        public async void Done()
+        {
+		    await Client.DeleteIndexAsync( i => i.Index( _defaultIndex ) );	
+        }
 
 		[Test]
 		public async Task CreateUser()
 		{
 			var store = CreateStore();
-			await CreateUser( store, new ElasticUser( UserName ) {
+			var user = new ElasticUser( UserName ) {
 				Phone = new ElasticUserPhone {
 					Number = "555 123 1234",
 					IsConfirmed = true
@@ -66,41 +59,82 @@ namespace Bmbsqd.ElasticIdentity.Tests
 					Address = "hello@world.com",
 					IsConfirmed = false
 				}
-			} );
+			};
 
-			var user = await store.FindByNameAsync( UserName );
+            await store.CreateAsync(user);
+
+			user = await store.FindByNameAsync( UserName );
 			Assert.That( user, Is.Not.Null );
 			Assert.That( user.UserName, Is.EqualTo( UserName ) );
 		}
+
+        [Test]
+        public async Task FindById()
+        { 
+            var store = CreateStore();            
+            var user = new ElasticUser( UserName );
+
+            await store.CreateAsync( user );
+
+            var elasticUser = await store.FindByIdAsync( user.Id );
+
+            Assert.IsNotNull( elasticUser );
+            Assert.AreEqual( user.Id, elasticUser.Id );
+
+            // should not throw when 404 is returned, it should return null instead to indicate resource not found
+            var user404 = await store.FindByIdAsync( "missing" );
+            
+            Assert.IsNull( user404 );
+        }        
+
+        [Test]
+        public async Task FindByEmail()
+        { 
+            var store = CreateStore();            
+            var user = new ElasticUser( UserName ) {
+                Email = new ElasticUserEmail {
+					Address = "hello@world.com",
+					IsConfirmed = false
+				}
+            };
+
+            await store.CreateAsync( user );
+
+            var elasticUser = await store.FindByEmailAsync( user.Email.Address );
+
+            Assert.IsNotNull( elasticUser );
+            Assert.AreEqual( user.EmailAddress, elasticUser.EmailAddress );
+        }
 
 		[Test]
 		public async Task DeleteUser()
 		{
 			var store = CreateStore();
-			var elasticUser = new ElasticUser( UserName );
-			await CreateUser( store, elasticUser );
+			var user = new ElasticUser( UserName );
+			
+            await store.CreateAsync(user);
 
-			await store.DeleteAsync( elasticUser );
+			await store.DeleteAsync( user );
 
-			var user = await store.FindByNameAsync( elasticUser.UserName );
-			Assert.That( user, Is.Null );
+			user = await store.FindByNameAsync( user.UserName );
+			Assert.That( user, Is.Null );            
 		}
 
 		[Test]
 		public async Task UpdateUser()
 		{
 			var store = CreateStore();
-			var elasticUser = new ElasticUser( UserName );
-			await CreateUser( store, elasticUser );
+			var user = new ElasticUser( UserName );
+			
+            await store.CreateAsync(user);
 
-			var user = await store.FindByIdAsync( elasticUser.UserName );
+			user = await store.FindByIdAsync( user.Id );
 			user.Roles.Add( "hello" );
 
 			await store.UpdateAsync( user );
-			user = await store.FindByIdAsync( elasticUser.Id );
+			user = await store.FindByIdAsync( user.Id );
 
 			Assert.That( user.Roles, Contains.Item( "hello" ) );
-			
 		}
 	}
 }

--- a/src/Bmbsqd.ElasticIdentity.Tests/TestBase.cs
+++ b/src/Bmbsqd.ElasticIdentity.Tests/TestBase.cs
@@ -8,11 +8,12 @@ namespace Bmbsqd.ElasticIdentity.Tests
 	public abstract class TestBase
 	{
 		protected readonly Uri _connectionString = new Uri( "http://localhost:9200/" );
+        protected readonly string _defaultIndex = "users_tests";
 
 		private IElasticClient _client;
 		protected IElasticClient Client
 		{
-			get { return _client ?? (_client = new ElasticClient( new ConnectionSettings( _connectionString ) )); }
+            get { return _client ?? ( _client = new ElasticClient( new ConnectionSettings( _connectionString, _defaultIndex ) ) ); }
 		}
 
 

--- a/src/Bmbsqd.ElasticIdentity.Tests/packages.config
+++ b/src/Bmbsqd.ElasticIdentity.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Elasticsearch.Net" version="1.0.0-beta1" targetFramework="net45" />
+  <package id="Elasticsearch.Net" version="1.0.0-rc1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.0.1" targetFramework="net45" />
-  <package id="NEST" version="1.0.0-beta1" targetFramework="net45" />
+  <package id="NEST" version="1.0.0-rc1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
 </packages>

--- a/src/Bmbsqd.ElasticIdentity/Bmbsqd.ElasticIdentity.csproj
+++ b/src/Bmbsqd.ElasticIdentity/Bmbsqd.ElasticIdentity.csproj
@@ -41,8 +41,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Elasticsearch.Net">
-      <HintPath>..\..\packages\Elasticsearch.Net.1.0.0-beta1\lib\Elasticsearch.Net.dll</HintPath>
+    <Reference Include="Elasticsearch.Net, Version=1.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Elasticsearch.Net.1.0.0-rc1\lib\Elasticsearch.Net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNet.Identity.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -50,7 +51,7 @@
     </Reference>
     <Reference Include="Nest, Version=1.0.0.0, Culture=neutral, PublicKeyToken=96c599bbe3e70f5d, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NEST.1.0.0-beta1\lib\Nest.dll</HintPath>
+      <HintPath>..\..\packages\NEST.1.0.0-rc1\lib\Nest.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Bmbsqd.ElasticIdentity/ElasticClaim.cs
+++ b/src/Bmbsqd.ElasticIdentity/ElasticClaim.cs
@@ -30,10 +30,10 @@ namespace Bmbsqd.ElasticIdentity
 {
 	public class ElasticClaim : IEquatable<ElasticClaim>
 	{
-		[ElasticProperty( IncludeInAll = false, Index = FieldIndexOption.not_analyzed )]
+		[ElasticProperty( IncludeInAll = false, Index = FieldIndexOption.NotAnalyzed )]
 		public string Type { get; set; }
 
-		[ElasticProperty( IncludeInAll = false, Index = FieldIndexOption.not_analyzed )]
+		[ElasticProperty( IncludeInAll = false, Index = FieldIndexOption.NotAnalyzed )]
 		public string Value { get; set; }
 
 		public ElasticClaim()

--- a/src/Bmbsqd.ElasticIdentity/ElasticUser.cs
+++ b/src/Bmbsqd.ElasticIdentity/ElasticUser.cs
@@ -22,6 +22,7 @@
 	CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 #endregion
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using Microsoft.AspNet.Identity;
@@ -29,17 +30,19 @@ using Nest;
 using Newtonsoft.Json;
 
 namespace Bmbsqd.ElasticIdentity
-{
-	[ElasticType( IdProperty = "userName" )]
+{	
 	public class ElasticUser : IUser
 	{
 		private readonly List<ElasticUserLoginInfo> _logins;
 		private readonly HashSet<ElasticClaim> _claims;
 		private readonly HashSet<string> _roles;
 		private string _userName;
+        private string _id;
 
 		public ElasticUser()
 		{
+            _id = Guid.NewGuid().ToString();
+
             _logins = new List<ElasticUserLoginInfo>();
 			_claims = new HashSet<ElasticClaim>();
 			_roles = new HashSet<string>();
@@ -51,12 +54,12 @@ namespace Bmbsqd.ElasticIdentity
 			UserName = userName;
 		}
 
-		[JsonIgnore]
-		[ElasticProperty( OptOut = true )]
-		public string Id
-		{
-			get { return UserName; }
-		}
+        [ElasticProperty( Analyzer = "lowercaseKeyword", Index = FieldIndexOption.NotAnalyzed )]
+        public virtual string Id
+        {
+            get { return _id; }
+			set { _id = value; }
+        }
 
 		[ElasticProperty( Analyzer = "lowercaseKeyword", IncludeInAll = false )]
 		public string UserName
@@ -65,11 +68,11 @@ namespace Bmbsqd.ElasticIdentity
 			set { _userName = UserNameUtils.FormatUserName( value ); }
 		}
 
-		[ElasticProperty( IncludeInAll = false, Index = FieldIndexOption.not_analyzed )]
+		[ElasticProperty( IncludeInAll = false, Index = FieldIndexOption.NotAnalyzed )]
 		[JsonProperty( DefaultValueHandling = DefaultValueHandling.Ignore )]
 		public string PasswordHash { get; set; }
 
-		[ElasticProperty( IncludeInAll = false, Index = FieldIndexOption.not_analyzed )]
+		[ElasticProperty( IncludeInAll = false, Index = FieldIndexOption.NotAnalyzed )]
 		[JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
 		public string SecurityStamp { get; set; }
 
@@ -108,7 +111,7 @@ namespace Bmbsqd.ElasticIdentity
 			get { return Email != null ? Email.Address : null; }
 		}
 
-		[ElasticProperty( IncludeInAll = false, Index = FieldIndexOption.not_analyzed )]
+		[ElasticProperty( IncludeInAll = false, Index = FieldIndexOption.NotAnalyzed )]
 		[JsonProperty( DefaultValueHandling = DefaultValueHandling.Ignore )]
 		[DefaultValue( false )]
 		public bool TwoFactorAuthenticationEnabled { get; set; }

--- a/src/Bmbsqd.ElasticIdentity/ElasticUserConfirmed.cs
+++ b/src/Bmbsqd.ElasticIdentity/ElasticUserConfirmed.cs
@@ -6,7 +6,7 @@ namespace Bmbsqd.ElasticIdentity
 {
 	public class ElasticUserConfirmed
 	{
-		[ElasticProperty( IncludeInAll = false, Index = FieldIndexOption.not_analyzed )]
+		[ElasticProperty( IncludeInAll = false, Index = FieldIndexOption.NotAnalyzed )]
 		[JsonProperty( DefaultValueHandling = DefaultValueHandling.Ignore )]
 		[DefaultValue( false )]
 		public bool IsConfirmed { get; set; }

--- a/src/Bmbsqd.ElasticIdentity/ElasticUserEmail.cs
+++ b/src/Bmbsqd.ElasticIdentity/ElasticUserEmail.cs
@@ -4,7 +4,7 @@ namespace Bmbsqd.ElasticIdentity
 {
 	public class ElasticUserEmail : ElasticUserConfirmed
 	{
-		[ElasticProperty( IncludeInAll = false, Index = FieldIndexOption.not_analyzed )]
+		[ElasticProperty( IncludeInAll = false, Index = FieldIndexOption.NotAnalyzed )]
 		public string Address { get; set; }
 
 	}

--- a/src/Bmbsqd.ElasticIdentity/ElasticUserLoginInfo.cs
+++ b/src/Bmbsqd.ElasticIdentity/ElasticUserLoginInfo.cs
@@ -4,10 +4,10 @@ namespace Bmbsqd.ElasticIdentity
 {
 	public class ElasticUserLoginInfo
 	{
-        [ElasticProperty(IncludeInAll = false, Index = FieldIndexOption.not_analyzed)]                
+        [ElasticProperty(IncludeInAll = false, Index = FieldIndexOption.NotAnalyzed)]                
         public string LoginProvider { get; set; }
 
-        [ElasticProperty(IncludeInAll = false, Index = FieldIndexOption.not_analyzed)]                
+        [ElasticProperty(IncludeInAll = false, Index = FieldIndexOption.NotAnalyzed)]                
         public string ProviderKey { get; set; }
 
 	}

--- a/src/Bmbsqd.ElasticIdentity/ElasticUserPhone.cs
+++ b/src/Bmbsqd.ElasticIdentity/ElasticUserPhone.cs
@@ -4,7 +4,7 @@ namespace Bmbsqd.ElasticIdentity
 {
 	public class ElasticUserPhone : ElasticUserConfirmed
 	{
-		[ElasticProperty( IncludeInAll = false, Index = FieldIndexOption.not_analyzed )]
+		[ElasticProperty( IncludeInAll = false, Index = FieldIndexOption.NotAnalyzed )]
 		public string Number { get; set; }
 	}
 }

--- a/src/Bmbsqd.ElasticIdentity/packages.config
+++ b/src/Bmbsqd.ElasticIdentity/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <packages>
-  <package id="Elasticsearch.Net" version="1.0.0-beta1" targetFramework="net45" />
+  <package id="Elasticsearch.Net" version="1.0.0-rc1" targetFramework="net45" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.0.1" targetFramework="net45" />
-  <package id="NEST" version="1.0.0-beta1" targetFramework="net45" />
+  <package id="NEST" version="1.0.0-rc1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Upgraded to NEST 1.0.0-rc1, which fixed several issues, including proper
exception handling for 404 status codes on GET requests.

Implemented FindAsync methods with GET async where applicable. Added the
unit tests.

Decoupled the Id property from Username and provided a default auto
generated value. A separate Id property might still be useful in
scenarios where passing a username or email in a url is not desired. The
UserManager is doing a nice job of falling back to the appropriate
method when searching by Id/Username/Email.
